### PR TITLE
fix: added missing refraction reference

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -8,6 +8,8 @@ src/style.css
 Makabaka1880, 2025. All rights reserved.
 */
 
+@import url('padding.css');
+
 html {
     scroll-behavior: smooth;
 }


### PR DESCRIPTION
After the last merge, I refactored all padding-related CSS, but the import was overwritten by the PR. This commit adds the missing reference.